### PR TITLE
CRUD operations for  student entity

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
       <profile name="Maven default annotation processors profile" enabled="true">
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />

--- a/src/main/java/edu/miu/attendifypro/controller/CourseController.java
+++ b/src/main/java/edu/miu/attendifypro/controller/CourseController.java
@@ -61,7 +61,7 @@ public class CourseController {
     }
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<CourseResponse>> getCourse(@PathVariable Long id, HttpServletRequest request) {
-        ServiceResponse<CourseResponse> serviceRsp= courseService.getAccount(id);
+        ServiceResponse<CourseResponse> serviceRsp= courseService.getCourse(id);
         ApiResponse<CourseResponse> apiResponse = ApiResponse.<CourseResponse>builder().status(false)
                 .code(serviceRsp.getStatusCode().name()).build();
         if (serviceRsp.getData().isPresent()) {

--- a/src/main/java/edu/miu/attendifypro/controller/StudentController.java
+++ b/src/main/java/edu/miu/attendifypro/controller/StudentController.java
@@ -41,7 +41,7 @@ public class StudentController {
             apiResponse.setData(serviceRsp.getData().get());
             apiResponse.setStatus(true);
         }
-        apiResponse.setMessage(messagingService.getResponseMessage(serviceRsp, new String[]{"course"}));
+        apiResponse.setMessage(messagingService.getResponseMessage(serviceRsp, new String[]{"student"}));
         return new ResponseEntity<ApiResponse<List<StudentResponse>>>(apiResponse,
                 serviceRsp.getStatusCode().getHttpStatusCode());
     }
@@ -50,16 +50,16 @@ public class StudentController {
         Pageable pageable = PageRequest.of(pageableReq.getPageNumber()>0? pageableReq.getPageNumber()-1 : 0,
                 pageableReq.getPageSize() ,
                 pageableReq.getSort());
-        ServiceResponse<Page<StudentResponse>> coursePage= studentService.getStudentPage(pageable);
+        ServiceResponse<Page<StudentResponse>> studentPage= studentService.getStudentPage(pageable);
         ApiResponse<Page<StudentResponse>> apiResponse = ApiResponse.<Page<StudentResponse>>builder().status(false)
-                .code(coursePage.getStatusCode().name()).build();
-        if (coursePage.getData().isPresent()) {
-            apiResponse.setData(coursePage.getData().get());
+                .code(studentPage.getStatusCode().name()).build();
+        if (studentPage.getData().isPresent()) {
+            apiResponse.setData(studentPage.getData().get());
             apiResponse.setStatus(true);
         }
-        apiResponse.setMessage(messagingService.getResponseMessage(coursePage, new String[]{"student"}));
+        apiResponse.setMessage(messagingService.getResponseMessage(studentPage, new String[]{"student"}));
         return new ResponseEntity<ApiResponse<Page<StudentResponse>>>(apiResponse,
-                coursePage.getStatusCode().getHttpStatusCode());
+                studentPage.getStatusCode().getHttpStatusCode());
     }
     @GetMapping("/{studentId}")
     public ResponseEntity<ApiResponse<StudentResponse>> getStudent(@PathVariable String studentId, HttpServletRequest request) {

--- a/src/main/java/edu/miu/attendifypro/controller/StudentController.java
+++ b/src/main/java/edu/miu/attendifypro/controller/StudentController.java
@@ -1,0 +1,126 @@
+package edu.miu.attendifypro.controller;
+
+import edu.miu.attendifypro.dto.request.StudentRequest;
+import edu.miu.attendifypro.dto.response.StudentResponse;
+import edu.miu.attendifypro.dto.response.common.ApiResponse;
+import edu.miu.attendifypro.dto.response.common.ServiceResponse;
+import edu.miu.attendifypro.service.MessagingService;
+import edu.miu.attendifypro.service.StudentService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/student")
+@CrossOrigin
+public class StudentController {
+    private static final Logger log = LoggerFactory.getLogger(StudentController.class);
+    private final StudentService studentService;
+
+
+    private final MessagingService messagingService;
+
+    public StudentController(StudentService studentService, MessagingService messagingService) {
+        this.studentService = studentService;
+        this.messagingService = messagingService;
+    }
+    @GetMapping("/all")
+    public ResponseEntity<ApiResponse<List<StudentResponse>>> getAllStudents() {
+        ServiceResponse<List<StudentResponse>> serviceRsp= studentService.getAllStudents();
+        ApiResponse<List<StudentResponse>> apiResponse = ApiResponse.<List<StudentResponse>>builder().status(false)
+                .code(serviceRsp.getStatusCode().name()).build();
+        if (serviceRsp.getData().isPresent()) {
+            apiResponse.setData(serviceRsp.getData().get());
+            apiResponse.setStatus(true);
+        }
+        apiResponse.setMessage(messagingService.getResponseMessage(serviceRsp, new String[]{"course"}));
+        return new ResponseEntity<ApiResponse<List<StudentResponse>>>(apiResponse,
+                serviceRsp.getStatusCode().getHttpStatusCode());
+    }
+    @GetMapping("")
+    public ResponseEntity<ApiResponse<Page<StudentResponse>>> getStudents(Pageable pageableReq) {
+        Pageable pageable = PageRequest.of(pageableReq.getPageNumber()>0? pageableReq.getPageNumber()-1 : 0,
+                pageableReq.getPageSize() ,
+                pageableReq.getSort());
+        ServiceResponse<Page<StudentResponse>> coursePage= studentService.getStudentPage(pageable);
+        ApiResponse<Page<StudentResponse>> apiResponse = ApiResponse.<Page<StudentResponse>>builder().status(false)
+                .code(coursePage.getStatusCode().name()).build();
+        if (coursePage.getData().isPresent()) {
+            apiResponse.setData(coursePage.getData().get());
+            apiResponse.setStatus(true);
+        }
+        apiResponse.setMessage(messagingService.getResponseMessage(coursePage, new String[]{"student"}));
+        return new ResponseEntity<ApiResponse<Page<StudentResponse>>>(apiResponse,
+                coursePage.getStatusCode().getHttpStatusCode());
+    }
+    @GetMapping("/{studentId}")
+    public ResponseEntity<ApiResponse<StudentResponse>> getStudent(@PathVariable String studentId, HttpServletRequest request) {
+        ServiceResponse<StudentResponse> serviceRsp= studentService.getStudent(studentId);
+        ApiResponse<StudentResponse> apiResponse = ApiResponse.<StudentResponse>builder().status(false)
+                .code(serviceRsp.getStatusCode().name()).build();
+        if (serviceRsp.getData().isPresent()) {
+            apiResponse.setData(serviceRsp.getData().get());
+            apiResponse.setStatus(true);
+        }
+        apiResponse.setMessage(messagingService.getResponseMessage(serviceRsp, new String[]{"student"}));
+        return new ResponseEntity<ApiResponse<StudentResponse>>(apiResponse,
+                serviceRsp.getStatusCode().getHttpStatusCode());
+    }
+
+    @PostMapping("")
+    public ResponseEntity<ApiResponse<StudentResponse>> create(@Valid @RequestBody StudentRequest studentCreateRequest,
+                                                              HttpServletRequest request) {
+        ServiceResponse<StudentResponse> serviceRsp= studentService.createStudent(studentCreateRequest);
+        ApiResponse<StudentResponse> apiResponse = ApiResponse.<StudentResponse>builder().status(false)
+                .code(serviceRsp.getStatusCode().name()).build();
+        if (serviceRsp.getData().isPresent()) {
+            apiResponse.setData(serviceRsp.getData().get());
+            apiResponse.setStatus(true);
+        }
+        apiResponse.setMessage(messagingService.getResponseMessage(serviceRsp, new String[]{"student"}));
+        return new ResponseEntity<ApiResponse<StudentResponse>>(apiResponse,
+                serviceRsp.getStatusCode().getHttpStatusCode());
+
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<StudentResponse>> update(@Valid @RequestBody StudentRequest studentUpdateRequest,
+                                                              @PathVariable String id,
+                                                              HttpServletRequest request) {
+        ServiceResponse<StudentResponse> serviceRsp= studentService.updateStudent(id,studentUpdateRequest);
+        ApiResponse<StudentResponse> apiResponse = ApiResponse.<StudentResponse>builder().status(false)
+                .code(serviceRsp.getStatusCode().name()).build();
+        if (serviceRsp.getData().isPresent()) {
+            apiResponse.setData(serviceRsp.getData().get());
+            apiResponse.setStatus(true);
+        }
+        apiResponse.setMessage(messagingService.getResponseMessage(serviceRsp, new String[]{"student"}));
+        return new ResponseEntity<ApiResponse<StudentResponse>>(apiResponse,
+                serviceRsp.getStatusCode().getHttpStatusCode());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Boolean>> delete(@PathVariable String id,
+                                                       HttpServletRequest request) {
+        ServiceResponse<Boolean> serviceRsp= studentService.deleteStudent(id);
+        ApiResponse<Boolean> apiResponse = ApiResponse.<Boolean>builder().status(false)
+                .code(serviceRsp.getStatusCode().name()).build();
+        if (serviceRsp.getData().isPresent()) {
+            apiResponse.setData(serviceRsp.getData().get());
+            apiResponse.setStatus(true);
+        }
+        apiResponse.setMessage(messagingService.getResponseMessage(serviceRsp, new String[]{"student"}));
+        return new ResponseEntity<ApiResponse<Boolean>>(apiResponse,
+                serviceRsp.getStatusCode().getHttpStatusCode());
+
+    }
+
+}

--- a/src/main/java/edu/miu/attendifypro/dto/request/StudentRequest.java
+++ b/src/main/java/edu/miu/attendifypro/dto/request/StudentRequest.java
@@ -28,12 +28,13 @@ public class StudentRequest {
     @Size(max = 20, message = "{validation.name.size.exceed}")
     private String applicantId;
 
-    private Faculty facultyAdvisor;
+    private String facultyAdvisorId;
 
     @NotBlank(message = "should.not.be.empty")
     @NotNull(message = "{required}")
     @Size(max = 50, message = "{validation.name.size.exceed}")
     private String firstName;
+
 
     @NotBlank(message = "should.not.be.empty")
     @NotNull(message = "{required}")

--- a/src/main/java/edu/miu/attendifypro/dto/request/StudentRequest.java
+++ b/src/main/java/edu/miu/attendifypro/dto/request/StudentRequest.java
@@ -1,0 +1,55 @@
+package edu.miu.attendifypro.dto.request;
+
+import edu.miu.attendifypro.domain.Faculty;
+import edu.miu.attendifypro.domain.auth.Account;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StudentRequest {
+
+    @NotNull(message = "{required}")
+    private LocalDate entry;
+
+    @NotBlank(message = "should.not.be.empty")
+    @NotNull(message = "{required}")
+    @Size(max = 15, message = "{validation.name.size.exceed}")
+    private String studentId;
+
+    @NotNull(message = "{required}")
+    @Size(max = 20, message = "{validation.name.size.exceed}")
+    private String applicantId;
+
+    private Faculty facultyAdvisor;
+
+    @NotBlank(message = "should.not.be.empty")
+    @NotNull(message = "{required}")
+    @Size(max = 50, message = "{validation.name.size.exceed}")
+    private String firstName;
+
+    @NotBlank(message = "should.not.be.empty")
+    @NotNull(message = "{required}")
+    @Size(max = 50, message = "{validation.name.size.exceed}")
+    private String lastName;
+
+    private LocalDate birthDate;
+
+    @Email
+    @NotBlank(message = "should.not.be.empty")
+    @NotNull(message = "{required}")
+    @Size(max = 30, message = "{validation.name.size.exceed}")
+    private String email;
+
+    private String gender;
+
+    private Account account;
+
+}

--- a/src/main/java/edu/miu/attendifypro/dto/request/StudentRequest.java
+++ b/src/main/java/edu/miu/attendifypro/dto/request/StudentRequest.java
@@ -2,6 +2,7 @@ package edu.miu.attendifypro.dto.request;
 
 import edu.miu.attendifypro.domain.Faculty;
 import edu.miu.attendifypro.domain.auth.Account;
+import jakarta.persistence.Column;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -28,7 +29,8 @@ public class StudentRequest {
     @Size(max = 20, message = "{validation.name.size.exceed}")
     private String applicantId;
 
-    private String facultyAdvisorId;
+    @Column(name="id")
+    private Long facultyAdvisorId;
 
     @NotBlank(message = "should.not.be.empty")
     @NotNull(message = "{required}")
@@ -50,7 +52,5 @@ public class StudentRequest {
     private String email;
 
     private String gender;
-
-    private Account account;
 
 }

--- a/src/main/java/edu/miu/attendifypro/dto/response/FacultyResponse.java
+++ b/src/main/java/edu/miu/attendifypro/dto/response/FacultyResponse.java
@@ -1,9 +1,27 @@
 package edu.miu.attendifypro.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class FacultyResponse {
+
+    private long id;
+
     private String firstName;
 
     private String lastName;
+
+    private LocalDate birthDate;
+
+    private String email;
+
+    private String gender;
 
     private String salutation;
 

--- a/src/main/java/edu/miu/attendifypro/dto/response/StudentResponse.java
+++ b/src/main/java/edu/miu/attendifypro/dto/response/StudentResponse.java
@@ -22,5 +22,4 @@ public class StudentResponse {
     private LocalDate birthDate;
     private String email;
     private String gender;
-    private Account account;
 }

--- a/src/main/java/edu/miu/attendifypro/dto/response/StudentResponse.java
+++ b/src/main/java/edu/miu/attendifypro/dto/response/StudentResponse.java
@@ -1,0 +1,26 @@
+package edu.miu.attendifypro.dto.response;
+
+import edu.miu.attendifypro.domain.Faculty;
+import edu.miu.attendifypro.domain.auth.Account;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StudentResponse {
+    private Long id;
+    private LocalDate entry;
+    private String studentId;
+    private String applicantId;
+    private Faculty facultyAdvisor;
+    private String firstName;
+    private String lastName;
+    private LocalDate birthDate;
+    private String email;
+    private String gender;
+    private Account account;
+}

--- a/src/main/java/edu/miu/attendifypro/dto/response/StudentResponse.java
+++ b/src/main/java/edu/miu/attendifypro/dto/response/StudentResponse.java
@@ -16,7 +16,7 @@ public class StudentResponse {
     private LocalDate entry;
     private String studentId;
     private String applicantId;
-    private Faculty facultyAdvisor;
+    private FacultyResponse facultyAdvisor;
     private String firstName;
     private String lastName;
     private LocalDate birthDate;

--- a/src/main/java/edu/miu/attendifypro/mapper/StudentDtoMapper.java
+++ b/src/main/java/edu/miu/attendifypro/mapper/StudentDtoMapper.java
@@ -1,0 +1,20 @@
+package edu.miu.attendifypro.mapper;
+
+import edu.miu.attendifypro.domain.Student;
+import edu.miu.attendifypro.dto.request.StudentRequest;
+import edu.miu.attendifypro.dto.response.StudentResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface StudentDtoMapper {
+    StudentDtoMapper dtoMapper =
+            Mappers.getMapper(StudentDtoMapper.class);
+
+    Student studentRequestToStudent(StudentRequest studentRequest);
+
+    StudentResponse studentToStudentResponse(Student student);
+
+
+}

--- a/src/main/java/edu/miu/attendifypro/mapper/StudentDtoMapper.java
+++ b/src/main/java/edu/miu/attendifypro/mapper/StudentDtoMapper.java
@@ -1,7 +1,9 @@
 package edu.miu.attendifypro.mapper;
 
+import edu.miu.attendifypro.domain.Faculty;
 import edu.miu.attendifypro.domain.Student;
 import edu.miu.attendifypro.dto.request.StudentRequest;
+import edu.miu.attendifypro.dto.response.FacultyResponse;
 import edu.miu.attendifypro.dto.response.StudentResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
@@ -15,6 +17,8 @@ public interface StudentDtoMapper {
     Student studentRequestToStudent(StudentRequest studentRequest);
 
     StudentResponse studentToStudentResponse(Student student);
+
+    FacultyResponse facultyToFacultyResponse(Faculty faculty);
 
 
 }

--- a/src/main/java/edu/miu/attendifypro/repository/StudentRepository.java
+++ b/src/main/java/edu/miu/attendifypro/repository/StudentRepository.java
@@ -1,0 +1,10 @@
+package edu.miu.attendifypro.repository;
+
+import edu.miu.attendifypro.domain.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StudentRepository extends JpaRepository<Student, Long> {
+    Optional<Student> findByStudentId(String studentId);
+}

--- a/src/main/java/edu/miu/attendifypro/service/CourseService.java
+++ b/src/main/java/edu/miu/attendifypro/service/CourseService.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface CourseService {
-    ServiceResponse<CourseResponse> getAccount(Long id);
+    ServiceResponse<CourseResponse> getCourse(Long id);
 
     ServiceResponse<Page<CourseResponse>> getCoursePage(Pageable pageable);
 

--- a/src/main/java/edu/miu/attendifypro/service/CourseServiceImpl.java
+++ b/src/main/java/edu/miu/attendifypro/service/CourseServiceImpl.java
@@ -37,7 +37,7 @@ public class CourseServiceImpl implements CourseService{
         }
     }
 
-    public ServiceResponse<CourseResponse> getAccount(Long id) {
+    public ServiceResponse<CourseResponse> getCourse(Long id) {
         try {
             Optional<Course> courseOpt = persistenceService.findById(id);
             if(courseOpt.isPresent()) {

--- a/src/main/java/edu/miu/attendifypro/service/StudentService.java
+++ b/src/main/java/edu/miu/attendifypro/service/StudentService.java
@@ -1,0 +1,24 @@
+package edu.miu.attendifypro.service;
+
+import edu.miu.attendifypro.dto.request.StudentRequest;
+import edu.miu.attendifypro.dto.response.StudentResponse;
+import edu.miu.attendifypro.dto.response.common.ServiceResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface StudentService {
+
+    ServiceResponse<StudentResponse> getStudent(String studentId);
+
+    ServiceResponse<Page<StudentResponse>> getStudentPage(Pageable pageable);
+
+    ServiceResponse<StudentResponse> createStudent(StudentRequest studentRequest);
+
+    ServiceResponse<StudentResponse> updateStudent(String id, StudentRequest studentUpdateRequest);
+
+    ServiceResponse<Boolean> deleteStudent(String id);
+
+    ServiceResponse<List<StudentResponse>> getAllStudents();
+}

--- a/src/main/java/edu/miu/attendifypro/service/StudentServiceImpl.java
+++ b/src/main/java/edu/miu/attendifypro/service/StudentServiceImpl.java
@@ -66,6 +66,12 @@ public class StudentServiceImpl implements StudentService {
 
     @Override
     public ServiceResponse<StudentResponse> createStudent(StudentRequest studentRequest) {
+
+        Optional<Student> studentOpt=persistenceService.findByStudentId(studentRequest.getStudentId());
+        if(studentOpt.isPresent()){
+            return ServiceResponse.of(AppStatusCode.E40006,List.of("student.id.exists"));
+        }
+
         try {
             Student student = StudentDtoMapper.dtoMapper.studentRequestToStudent(studentRequest);
 

--- a/src/main/java/edu/miu/attendifypro/service/StudentServiceImpl.java
+++ b/src/main/java/edu/miu/attendifypro/service/StudentServiceImpl.java
@@ -7,8 +7,6 @@ import edu.miu.attendifypro.dto.response.StudentResponse;
 import edu.miu.attendifypro.dto.response.common.ServiceResponse;
 import edu.miu.attendifypro.mapper.StudentDtoMapper;
 import edu.miu.attendifypro.service.persistence.StudentPersistenceService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,7 +17,6 @@ import java.util.*;
 @Service
 public class StudentServiceImpl implements StudentService {
 
-    private static final Logger log = LoggerFactory.getLogger(StudentServiceImpl.class);
     private final StudentPersistenceService persistenceService;
 
     public StudentServiceImpl(StudentPersistenceService persistenceService) {
@@ -65,6 +62,9 @@ public class StudentServiceImpl implements StudentService {
     public ServiceResponse<StudentResponse> createStudent(StudentRequest studentRequest) {
         try {
             Student student = StudentDtoMapper.dtoMapper.studentRequestToStudent(studentRequest);
+            // Add this once faculty is implemented
+//            Optional<Faculty> facultyAdvisor = facultyRepository.findById(studentRequest.getFacultyAdvisorId());
+//            facultyAdvisor.ifPresent(student::setFacultyAdvisor);
             persistenceService.save(student);
             return ServiceResponse.of(StudentDtoMapper.dtoMapper.studentToStudentResponse(student),AppStatusCode.S20001);
 
@@ -92,8 +92,11 @@ public class StudentServiceImpl implements StudentService {
                 student.setEntry(studentUpdateRequest.getEntry());
                 student.setGender(studentUpdateRequest.getGender());
                 student.setBirthDate(studentUpdateRequest.getBirthDate());
-                student.setFacultyAdvisor(studentUpdateRequest.getFacultyAdvisor());
                 student.setAccount(studentUpdateRequest.getAccount());
+
+                // Add this once faculty is implemented
+//            Optional<Faculty> facultyAdvisor = facultyRepository.findById(studentRequest.getFacultyAdvisorId());
+//            facultyAdvisor.ifPresent(student::setFacultyAdvisor);
                 persistenceService.save(student);
                 return ServiceResponse.of(StudentDtoMapper.dtoMapper.studentToStudentResponse(student),AppStatusCode.S20002);
             }

--- a/src/main/java/edu/miu/attendifypro/service/StudentServiceImpl.java
+++ b/src/main/java/edu/miu/attendifypro/service/StudentServiceImpl.java
@@ -1,11 +1,13 @@
 package edu.miu.attendifypro.service;
 
 import edu.miu.attendifypro.domain.AppStatusCode;
+import edu.miu.attendifypro.domain.Faculty;
 import edu.miu.attendifypro.domain.Student;
 import edu.miu.attendifypro.dto.request.StudentRequest;
 import edu.miu.attendifypro.dto.response.StudentResponse;
 import edu.miu.attendifypro.dto.response.common.ServiceResponse;
 import edu.miu.attendifypro.mapper.StudentDtoMapper;
+import edu.miu.attendifypro.repository.FacultyRepository;
 import edu.miu.attendifypro.service.persistence.StudentPersistenceService;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -19,8 +21,11 @@ public class StudentServiceImpl implements StudentService {
 
     private final StudentPersistenceService persistenceService;
 
-    public StudentServiceImpl(StudentPersistenceService persistenceService) {
+    FacultyRepository facultyRepository;
+
+    public StudentServiceImpl(StudentPersistenceService persistenceService, FacultyRepository facultyRepository) {
         this.persistenceService = persistenceService;
+        this.facultyRepository = facultyRepository;
     }
 
     @Override
@@ -62,9 +67,10 @@ public class StudentServiceImpl implements StudentService {
     public ServiceResponse<StudentResponse> createStudent(StudentRequest studentRequest) {
         try {
             Student student = StudentDtoMapper.dtoMapper.studentRequestToStudent(studentRequest);
-            // Add this once faculty is implemented
-//            Optional<Faculty> facultyAdvisor = facultyRepository.findById(studentRequest.getFacultyAdvisorId());
-//            facultyAdvisor.ifPresent(student::setFacultyAdvisor);
+
+            Optional<Faculty> facultyAdvisor = facultyRepository.findById(studentRequest.getFacultyAdvisorId());
+            facultyAdvisor.ifPresent(student::setFacultyAdvisor);
+
             persistenceService.save(student);
             return ServiceResponse.of(StudentDtoMapper.dtoMapper.studentToStudentResponse(student),AppStatusCode.S20001);
 
@@ -92,11 +98,10 @@ public class StudentServiceImpl implements StudentService {
                 student.setEntry(studentUpdateRequest.getEntry());
                 student.setGender(studentUpdateRequest.getGender());
                 student.setBirthDate(studentUpdateRequest.getBirthDate());
-                student.setAccount(studentUpdateRequest.getAccount());
 
-                // Add this once faculty is implemented
-//            Optional<Faculty> facultyAdvisor = facultyRepository.findById(studentRequest.getFacultyAdvisorId());
-//            facultyAdvisor.ifPresent(student::setFacultyAdvisor);
+            Optional<Faculty> facultyAdvisor = facultyRepository.findById(studentUpdateRequest.getFacultyAdvisorId());
+            facultyAdvisor.ifPresent(student::setFacultyAdvisor);
+
                 persistenceService.save(student);
                 return ServiceResponse.of(StudentDtoMapper.dtoMapper.studentToStudentResponse(student),AppStatusCode.S20002);
             }

--- a/src/main/java/edu/miu/attendifypro/service/StudentServiceImpl.java
+++ b/src/main/java/edu/miu/attendifypro/service/StudentServiceImpl.java
@@ -8,6 +8,7 @@ import edu.miu.attendifypro.dto.response.StudentResponse;
 import edu.miu.attendifypro.dto.response.common.ServiceResponse;
 import edu.miu.attendifypro.mapper.StudentDtoMapper;
 import edu.miu.attendifypro.repository.FacultyRepository;
+import edu.miu.attendifypro.service.persistence.FacultyPersistenceService;
 import edu.miu.attendifypro.service.persistence.StudentPersistenceService;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -21,11 +22,11 @@ public class StudentServiceImpl implements StudentService {
 
     private final StudentPersistenceService persistenceService;
 
-    FacultyRepository facultyRepository;
+    private final FacultyPersistenceService facultyPersistenceService;
 
-    public StudentServiceImpl(StudentPersistenceService persistenceService, FacultyRepository facultyRepository) {
+    public StudentServiceImpl(StudentPersistenceService persistenceService, FacultyPersistenceService facultyPersistenceService) {
         this.persistenceService = persistenceService;
-        this.facultyRepository = facultyRepository;
+        this.facultyPersistenceService = facultyPersistenceService;
     }
 
     @Override
@@ -68,7 +69,7 @@ public class StudentServiceImpl implements StudentService {
         try {
             Student student = StudentDtoMapper.dtoMapper.studentRequestToStudent(studentRequest);
 
-            Optional<Faculty> facultyAdvisor = facultyRepository.findById(studentRequest.getFacultyAdvisorId());
+            Optional<Faculty> facultyAdvisor = facultyPersistenceService.findById(studentRequest.getFacultyAdvisorId());
             facultyAdvisor.ifPresent(student::setFacultyAdvisor);
 
             persistenceService.save(student);
@@ -99,7 +100,7 @@ public class StudentServiceImpl implements StudentService {
                 student.setGender(studentUpdateRequest.getGender());
                 student.setBirthDate(studentUpdateRequest.getBirthDate());
 
-            Optional<Faculty> facultyAdvisor = facultyRepository.findById(studentUpdateRequest.getFacultyAdvisorId());
+            Optional<Faculty> facultyAdvisor = facultyPersistenceService.findById(studentUpdateRequest.getFacultyAdvisorId());
             facultyAdvisor.ifPresent(student::setFacultyAdvisor);
 
                 persistenceService.save(student);

--- a/src/main/java/edu/miu/attendifypro/service/StudentServiceImpl.java
+++ b/src/main/java/edu/miu/attendifypro/service/StudentServiceImpl.java
@@ -1,0 +1,121 @@
+package edu.miu.attendifypro.service;
+
+import edu.miu.attendifypro.domain.AppStatusCode;
+import edu.miu.attendifypro.domain.Student;
+import edu.miu.attendifypro.dto.request.StudentRequest;
+import edu.miu.attendifypro.dto.response.StudentResponse;
+import edu.miu.attendifypro.dto.response.common.ServiceResponse;
+import edu.miu.attendifypro.mapper.StudentDtoMapper;
+import edu.miu.attendifypro.service.persistence.StudentPersistenceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class StudentServiceImpl implements StudentService {
+
+    private static final Logger log = LoggerFactory.getLogger(StudentServiceImpl.class);
+    private final StudentPersistenceService persistenceService;
+
+    public StudentServiceImpl(StudentPersistenceService persistenceService) {
+        this.persistenceService = persistenceService;
+    }
+
+    @Override
+    public ServiceResponse<List<StudentResponse>> getAllStudents() {
+        try {
+            List<Student> studentList = persistenceService.findAll();
+            List<StudentResponse> studentResponses =studentList.stream().map(StudentDtoMapper.dtoMapper::studentToStudentResponse).toList();
+            return ServiceResponse.of(studentResponses, AppStatusCode.S20000);
+        }
+        catch (Exception e){
+            return ServiceResponse.of(AppStatusCode.E50002);
+        }
+    }
+
+    @Override
+    public ServiceResponse<StudentResponse> getStudent(String studentId) {
+        try {
+            Optional<Student> studentOpt = persistenceService.findByStudentId(studentId);
+            return studentOpt.map(student -> ServiceResponse.of(StudentDtoMapper.dtoMapper.studentToStudentResponse(student), AppStatusCode.S20005)).orElseGet(() -> ServiceResponse.of(AppStatusCode.E40004));
+        }
+        catch (Exception e){
+            return ServiceResponse.of(AppStatusCode.E50001);
+        }
+    }
+
+    @Override
+    public ServiceResponse<Page<StudentResponse>> getStudentPage(Pageable pageable) {
+        try {
+            Page<Student> studentPage = persistenceService.findAll(pageable);
+            Page<StudentResponse> studentDtoPage = studentPage.map(StudentDtoMapper.dtoMapper::studentToStudentResponse);
+            return ServiceResponse.of(studentDtoPage, AppStatusCode.S20000);
+        }
+        catch (Exception e){
+            return ServiceResponse.of(AppStatusCode.E50002);
+        }
+    }
+
+    @Override
+    public ServiceResponse<StudentResponse> createStudent(StudentRequest studentRequest) {
+        try {
+            Student student = StudentDtoMapper.dtoMapper.studentRequestToStudent(studentRequest);
+            persistenceService.save(student);
+            return ServiceResponse.of(StudentDtoMapper.dtoMapper.studentToStudentResponse(student),AppStatusCode.S20001);
+
+        }catch(DataIntegrityViolationException ex){
+            return ServiceResponse.of(AppStatusCode.E40002);
+        }
+        catch (Exception e){
+            return ServiceResponse.of(AppStatusCode.E50003);
+        }
+    }
+
+    @Override
+    public ServiceResponse<StudentResponse> updateStudent(String id, StudentRequest studentUpdateRequest) {
+        Optional<Student> studentOpt=persistenceService.findByStudentId(id);
+        if(studentOpt.isEmpty()){
+            return ServiceResponse.of(AppStatusCode.E40006,List.of("student.id.doesn't.exists"));
+        }
+
+            try {
+                Student student = studentOpt.get();
+                student.setApplicantId(studentUpdateRequest.getApplicantId());
+                student.setFirstName(studentUpdateRequest.getFirstName());
+                student.setLastName(studentUpdateRequest.getLastName());
+                student.setEmail(studentUpdateRequest.getEmail());
+                student.setEntry(studentUpdateRequest.getEntry());
+                student.setGender(studentUpdateRequest.getGender());
+                student.setBirthDate(studentUpdateRequest.getBirthDate());
+                student.setFacultyAdvisor(studentUpdateRequest.getFacultyAdvisor());
+                student.setAccount(studentUpdateRequest.getAccount());
+                persistenceService.save(student);
+                return ServiceResponse.of(StudentDtoMapper.dtoMapper.studentToStudentResponse(student),AppStatusCode.S20002);
+            }
+            catch (Exception e){
+                return ServiceResponse.of(AppStatusCode.E50002);
+            }
+        }
+
+    @Override
+    public ServiceResponse<Boolean> deleteStudent(String id) {
+        try {
+            Optional<Student> studentOpt = persistenceService.findByStudentId(id);
+            if(studentOpt.isPresent()) {
+                persistenceService.delete(studentOpt.get());
+                return ServiceResponse.of(true,AppStatusCode.S20003);
+            }
+            else{
+                return ServiceResponse.of(AppStatusCode.E40004);
+            }
+        }
+        catch (Exception e){
+            return ServiceResponse.of(AppStatusCode.E50005);
+        }
+    }
+}

--- a/src/main/java/edu/miu/attendifypro/service/persistence/FacultyPersistenceService.java
+++ b/src/main/java/edu/miu/attendifypro/service/persistence/FacultyPersistenceService.java
@@ -14,7 +14,7 @@ public interface FacultyPersistenceService {
 
     Optional<Faculty> findById(Long id);
 
-    Faculty save(Faculty course);
+    Faculty save(Faculty faculty);
 
-    void delete(Faculty course);
+    void delete(Faculty faculty);
 }

--- a/src/main/java/edu/miu/attendifypro/service/persistence/StudentPersistenceService.java
+++ b/src/main/java/edu/miu/attendifypro/service/persistence/StudentPersistenceService.java
@@ -1,0 +1,22 @@
+package edu.miu.attendifypro.service.persistence;
+
+import edu.miu.attendifypro.domain.Student;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StudentPersistenceService {
+    List<Student> findAll();
+
+    Page<Student> findAll(Pageable pageable);
+
+    Optional<Student> findByStudentId(String studentId);
+
+    Student save(Student student);
+
+    void delete(Student student);
+
+    Optional<Student> findById(Long id);
+}

--- a/src/main/java/edu/miu/attendifypro/service/persistence/impl/StudentPersistenceServiceImpl.java
+++ b/src/main/java/edu/miu/attendifypro/service/persistence/impl/StudentPersistenceServiceImpl.java
@@ -1,0 +1,53 @@
+package edu.miu.attendifypro.service.persistence.impl;
+
+import edu.miu.attendifypro.domain.Student;
+import edu.miu.attendifypro.repository.StudentRepository;
+import edu.miu.attendifypro.service.persistence.StudentPersistenceService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class StudentPersistenceServiceImpl implements StudentPersistenceService {
+    private final StudentRepository studentRepository;
+
+
+    public StudentPersistenceServiceImpl(StudentRepository studentRepository) {
+        this.studentRepository = studentRepository;
+    }
+
+    @Override
+    public List<Student> findAll() {
+        return studentRepository.findAll();
+    }
+
+    @Override
+    public Page<Student> findAll(Pageable pageable) {
+        return studentRepository.findAll(pageable);
+    }
+
+    @Override
+    public Optional<Student> findByStudentId(String studentId) {
+        return studentRepository.findByStudentId(studentId);
+    }
+
+    @Override
+    public Student save(Student student) {
+        return studentRepository.save(student);
+    }
+
+    @Override
+    public void delete(Student student) {
+        studentRepository.delete(student);
+    }
+
+    @Override
+    public Optional<Student> findById(Long id) {
+        return Optional.empty();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/attendify-pro?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=UTC
     username: root
-    password: password
+    password:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:

--- a/src/test/java/edu/miu/attendifypro/service/CourseServiceImplTest.java
+++ b/src/test/java/edu/miu/attendifypro/service/CourseServiceImplTest.java
@@ -92,7 +92,7 @@ class CourseServiceImplTest {
     void getAccount_Success() {
         when(persistenceService.findById(1L)).thenReturn(Optional.of(course));
 
-        ServiceResponse<CourseResponse> response = courseService.getAccount(1L);
+        ServiceResponse<CourseResponse> response = courseService.getCourse(1L);
 
         assertEquals(AppStatusCode.S20005, response.getStatusCode());
         assertNotNull(response.getData());
@@ -103,7 +103,7 @@ class CourseServiceImplTest {
     void getAccount_NotFound() {
         when(persistenceService.findById(1L)).thenReturn(Optional.empty());
 
-        ServiceResponse<CourseResponse> response = courseService.getAccount(1L);
+        ServiceResponse<CourseResponse> response = courseService.getCourse(1L);
 
         assertEquals(AppStatusCode.E40004, response.getStatusCode());
         verify(persistenceService, times(1)).findById(1L);
@@ -113,7 +113,7 @@ class CourseServiceImplTest {
     void getAccount_Failure() {
         when(persistenceService.findById(1L)).thenThrow(new RuntimeException());
 
-        ServiceResponse<CourseResponse> response = courseService.getAccount(1L);
+        ServiceResponse<CourseResponse> response = courseService.getCourse(1L);
 
         assertEquals(AppStatusCode.E50001, response.getStatusCode());
         verify(persistenceService, times(1)).findById(1L);


### PR DESCRIPTION
Issues
- `Account` Entity Presence in StudentRequest class is to be removed. You can use username,password field within the same request as a field. Don't necessarily need to nest dtos as per entity structure.
- Similar is the case with `private Faculty facultyAdvisor;` field. You need only the facultys id. And then you can validate the id and then load the advisor entity inside the student object before saving. 

Feedbacks:
- Naming of variables. I see there are varibles with 'course' in them. Please rename them to corresponding student values.
-  private static final Logger log = LoggerFactory.getLogger(StudentServiceImpl.class);  Log declaration doesn't need to be done as we have been using lombok.
